### PR TITLE
Add ability to build docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.5.1-onbuild
+
+# Setup private key for accessing private repos
+ADD id_rsa /root/.ssh/id_rsa
+RUN chmod 600 /root/.ssh/id_rsa
+RUN ssh-keyscan -t rsa github.com >> /root/.ssh/known_hosts
+
+

--- a/README.md
+++ b/README.md
@@ -92,3 +92,17 @@ you pull the code using `go get` and build using the provided `Makefile`.
     $ go get github.com/uswitch/dagr
     $ make -C src/github.com/uswitch/dagr deps
     $ make -C src/github.com/uswitch/dagr
+
+### Docker
+
+The Dockerfile requires that a RSA key be present that has read-only access to the github repo to be watched. 
+The file should be named `id_rsa` and be copied into the same folder as the Dockerfile.
+
+The entrypoint to the Dockerfile is provided such that only the github repository flag is required as the command parameter when run.
+
+Usage:
+
+```bash
+docker-compose build
+docker-compose run dagr --repo git@github.com:uswitch/dagr-sample-programs
+```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+dagr:
+  build: .
+  entrypoint:
+    - go-wrapper
+    - run
+    - --http
+    - :8080
+    - --work
+    - /tmp/dagr-work
+    - --ui
+    - ./ui
+  ports:
+    - "8080:8080"


### PR DESCRIPTION
Dockerfile produces image with an entry point that only requires the github repo parameter
