### PR TITLE
Now prints what the actuall error if we cant upgrade to websocket

### DIFF
--- a/web/executionMessages.go
+++ b/web/executionMessages.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"fmt"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	"github.com/uswitch/dagr/app"
@@ -19,7 +20,7 @@ func programExecutions(app app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		conn, err := upgrader.Upgrade(w, req, nil)
 		if err != nil {
-			log.Println("cannot upgrade to websocket")
+			log.Println(fmt.Errorf("cannot upgrade to websocket: %v", err))
 			return
 		}
 		vars := mux.Vars(req)
@@ -41,7 +42,7 @@ func handleExecutionMessages(app app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		conn, err := upgrader.Upgrade(w, req, nil)
 		if err != nil {
-			log.Println("cannot upgrade to websocket")
+			log.Println(fmt.Errorf("cannot upgrade to websocket: %v", err))
 			return
 		}
 		vars := mux.Vars(req)


### PR DESCRIPTION
Back office got a problem where the websocket stuff isn't working behind load balancing. Would be nice to see the actual error message, this does that
